### PR TITLE
Update lambdapi syntax

### DIFF
--- a/encoding/coercions.lp
+++ b/encoding/coercions.lp
@@ -1,6 +1,6 @@
 require open personoj.lhol personoj.pvs_cert;
 
-coercion #c (El (psub [$a] $p)) $t $b ↪ #c (El $a) (fst [$a] [$p] $t) $b;
-assert (a: Set) (p: El a → Prop) (x: El (psub p)) ⊢ x : El a;
-coercion #c $a $t (El (psub [$b] $p)) ↪ pair [$b] [$p] (#c $a $t (El $b)) _;
+coerce_rule coerce (El (psub [$a] $p)) $b $t ↪ coerce (El $a) $b (fst [$a] [$p] $t);
+assert (a: Set) (p: El a → Prop) (x: El (psub [a] p)) ⊢ x : El a;
+coerce_rule coerce $a (El (psub [$b] $p)) $t ↪ pair [$b] [$p] (coerce $a (El $b) $t) _;
 assert (a: Set) (p: El a → Prop) (x: El a) ⊢ x : El (psub p);

--- a/encoding/telescope.lp
+++ b/encoding/telescope.lp
@@ -166,33 +166,33 @@ require open personoj.coercions;
    checking of coercions yet. */
 
 // Non dependent coercion
-coercion #c (El (code [A.s $l] (cons! $a $v))) $arg (El (code (cons! $b $w))) ↪
+coerce_rule coerce (El (code [A.s $l] (cons! $a $v))) (El (code (cons! $b $w))) $arg ↪
   @cons $l $b $w
-     (#c (El $a) (@car (A.s $l) (@cons! $l $a $v) $arg) (El $b))
-     (#c (El (@code $l $v)) (@cdr $l (@cons! $l $a $v) $arg) (El (@code $l $w)));
+     (coerce (El $a) (El $b) (@car (A.s $l) (@cons! $l $a $v) $arg))
+     (coerce (El (@code $l $v)) (El (@code $l $w)) (@cdr $l (@cons! $l $a $v) $arg));
 
 assert (a: Set) (p: El a → Prop) (x: El (psub p)) ⊢ double x x : El (code (double! a a));
 
 // Dependent coercion
-coercion #c (El (code [A.s $l] (&cons! $a $v))) $arg (El (code (&cons! $b $w))) ↪
+coerce_rule coerce (El (code [A.s $l] (&cons! $a $v))) (El (code (&cons! $b $w))) $arg ↪
   let old-car : El $a ≔ @car (A.s $l) (&cons! $a $v) $arg in
-  let new-car : El $b ≔ #c (El $a) (@car (A.s $l) (@&cons! $l $a $v) $arg) (El $b) in
+  let new-car : El $b ≔ coerce (El $a) (El $b) (@car (A.s $l) (@&cons! $l $a $v) $arg) in
   @&cons $l $b $w new-car
-     (#c (El (@code $l ($v old-car))) (@cdr $l (@&cons! $l $a $v) $arg) (El (@code $l $w)));
+     (coerce (El (@code $l ($v old-car))) (El (@code $l $w)) (@cdr $l (@&cons! $l $a $v) $arg));
 
 assert (nat: Set) (<: El (nat ~> nat ~> prop))
        (n: El nat) (ln: El (psub (λ k, < k n))) ⊢
   &double n ln : El (code (&double! nat nat));
 
 // Going from non dependent to dependent
-coercion #c (El (code [A.s $l] (cons! $a $v))) $arg (El (code (&cons! $b $w))) ↪
+coerce_rule coerce (El (code [A.s $l] (cons! $a $v))) (El (code (&cons! $b $w))) $arg ↪
   let new-car : El $b ≔
-    #c (El $a) (@car (A.s $l) (@cons! $l $a $v) $arg) (El $b)
+    coerce (El $a) (El $b) (@car (A.s $l) (@cons! $l $a $v) $arg)
   in
   @&cons $l $b $w new-car
-         (#c (El (@code $l $v))
-             (@cdr $l (@cons! $l $a $v) $arg)
-             (El (@code $l ($w new-car))));
+         (coerce (El (@code $l $v))
+                 (El (@code $l ($w new-car)))
+                 (@cdr $l (@cons! $l $a $v) $arg));
 
 assert
   // Example of coercion from non dependent to dependent telescope:


### PR DESCRIPTION
Follow lambdapi fork's update https://github.com/gabrielhdt/lambdapi/commit/[e167854](https://github.com/gabrielhdt/lambdapi/commit/e16785471d2caf5da85bb52bbfa27393037ba675)
in order to use upstream's lambdapi syntax where possible.